### PR TITLE
Add more Typedefs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 
 # local dev files
 /?.js
+
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ API
 
 ### pyre(String pattern[, Array keys]) → RegExp
 
-Returns a JavaScript RegExp instance from the given Python-compatible string.
+Returns a JavaScript RegExp instance from the given Python-like regular expression string.
 
-An empty array may be passsed in as the second argument, which will be
+An empty array may be passed in as the second argument, which will be
 populated with the "named capture group" names as Strings in the Array,
 once the RegExp has been returned.
+
+The returned RegExp has an additional function `pyreReplace`, for Python-like replacements

--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ exports = module.exports = pyre;
  * once the RegExp has been returned.
  *
  * @param {String} pattern - Python-like regexp string to compile to a JS RegExp
- * @return {RegExp} returns a JavaScript RegExp instance from the given `pattern`
+ * @return {import("./types").PyreRegExp} returns a JavaScript RegExp from the given `pattern`,
+ *  with an additional function `pyreReplace` for Python-like replacement
  * @public
  */
 function pyre(pattern, namedCaptures) {

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,9 @@
+export declare class PyreRegExp extends RegExp {
+    /**
+     * Use the RegExp to preform a python-like replacement on a string.
+     * 
+     * @param source string to preform the replacement on
+     * @param replacement replacement string
+     */
+    public pyreReplace(source: string, replacement: string): string;
+}


### PR DESCRIPTION
Adds typedefs for the `pyreReplace` function to the package.
This PR makes the package typescript compatible.

![image](https://user-images.githubusercontent.com/44241786/223395581-09e09d94-0989-4629-af80-5ca1d0fccf7b.png)

---

I hereby agree to license these contributions to the pyre-to-regexp codebase under the [MIT license](https://opensource.org/licenses/MIT).
